### PR TITLE
Use OpenGL commands only in paintGL()

### DIFF
--- a/View/Widgets/GLWidget.cpp
+++ b/View/Widgets/GLWidget.cpp
@@ -441,14 +441,8 @@ void GLWidget::updateView()
     mViewMatrix.rotate(-90, 1.0, 0.0, 0.0);
 }
 
-#ifdef GLES
 void GLWidget::paintGL()
 {
-#else
-void GLWidget::paintEvent(QPaintEvent *pe)
-{
-    Q_UNUSED(pe)
-#endif
     QPainter painter(this);
 
     // Segment counter

--- a/View/Widgets/GLWidget.h
+++ b/View/Widgets/GLWidget.h
@@ -133,11 +133,7 @@ protected:
     void resizeGL(int width, int height);
     void updateProjection();
     void updateView();
-#ifdef GLES
     void paintGL();
-#else
-    void paintEvent(QPaintEvent *pe);
-#endif
 
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);


### PR DESCRIPTION
I compiled CoconutCNC from source on MacOS High Sierra and experienced a lot of crashes when launching the application. Upon debugging the issue I found that an assert inside glClearColor() within paintevent() triggered. The assert was checking whether OpenGL had been initialized. Indeed, initializeGL() was NOT called before the paintEvent appeared.

I read the documentation on QtOpenGL and the way I understand it is, that OpenGL commands have to be put inside paintGL(), which is called by the paintEvent() handler of the base class, which also takes care of properly calling initializeGL().

So I removed paintEvent() and renamed it in non-GLES code to paintGL(). That fixed the issue. OpenGL is now properly initialized and drawing works.

I don't really understand why there are OpenGL calls being issued in paintEvent(), but I believe this is wrong.

I'm also not sure why GLWidget inherits from QOpenGLWidget with GLES and from QGLWidget otherwise. My understanding is that QGLWidget is for backwards-compatibility with older Qt-Versions and QOpenGLWidget is its modern substitute. So I think QOpenGLWidget can always be used.

I'm also not sure if the #ifdef GLES-stuff is really needed. Shouldn't that be handled by Qt?

I'm new to the Candle code base and I'm happy to discuss this issue and make further fixes, if necessary.